### PR TITLE
Fixed usfb2osis always clearing caller

### DIFF
--- a/src/usfm2osis.cpp
+++ b/src/usfm2osis.cpp
@@ -1913,9 +1913,7 @@ OSIS: <note osisRef="Gen.3.20" osisID="Gen.3.20!footnote.2" n="2"><catchWord>Ê-
   }    
   
   // Derive the caller as to be put in the OSIS note.
-  if (caller == "+")
-    caller.clear();
-  if (caller == "-");
+  if (caller == "+" || caller == "-")
     caller.clear();
   
   // Write the osisID.

--- a/src/usfm2osis.cpp
+++ b/src/usfm2osis.cpp
@@ -1913,8 +1913,9 @@ OSIS: <note osisRef="Gen.3.20" osisID="Gen.3.20!footnote.2" n="2"><catchWord>Ê-
   }    
   
   // Derive the caller as to be put in the OSIS note.
-  if (caller == "+" || caller == "-")
+  if ((caller == "+") || (caller == "-")) {
     caller.clear();
+  }
   
   // Write the osisID.
   ustring note_osis_id = verse_osis_id + "!";


### PR DESCRIPTION
GCC 6 spotted this bug for me, the semicolon meant that the second if statement did not contain the clear call. @postiffm could you check that this produces the intended result? If that's not the case, then the if statement should simply be removed.